### PR TITLE
refactor: replace structopt with clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 edition = "2024"
 
 [dependencies]
-structopt = { version = "0.3", default-features = false }
+clap = { version = "4.5", features = ["derive", "env"] }
 redis = { version = "0.29", features = ["streams", "tokio-comp", "connection-manager"] }
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
@@ -16,5 +16,4 @@ anyhow = "1.0"
 [dev-dependencies]
 simple_logger = "5.0"
 tokio = { version = "1.43", features = ["macros"] }
-# serde-redis = { version = "1.29", git = "https://github.com/ezex-io/serde-redis" }
-serde-redis = { path = "../serde-redis" }
+serde_redis = { version = "0.29", git = "https://github.com/ezex-io/serde-redis" }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,9 @@
 use super::config::Config;
 pub use super::{bus::StreamBus, stream::Stream};
 use async_trait::async_trait;
-use futures::channel::mpsc::{channel, Receiver, Sender};
 use futures::FutureExt;
-use futures::{select, SinkExt};
+use futures::channel::mpsc::{Receiver, Sender, channel};
+use futures::{SinkExt, select};
 use futures_util::StreamExt;
 #[cfg(not(test))]
 use log::{error, info, trace, warn};
@@ -163,11 +163,8 @@ impl StreamBus for RedisClient {
 
                         let mut map = BTreeMap::new();
                         for (k, v) in stream.fields {
-                            match v {
-                                redis::Value::BulkString(d) => {
-                                    map.insert(k, d);
-                                }
-                                _ => {}
+                            if let redis::Value::BulkString(d) = v {
+                                map.insert(k, d);
                             }
                         }
                         match con_add.xadd_map::<_, _, BTreeMap<String, Vec<u8>>, String>(
@@ -222,5 +219,5 @@ async fn register_running<'a>(
         }
         ids.push(">");
     }
-    return ids;
+    ids
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,12 @@
-use serde::{Deserialize, Serialize};
-use structopt::StructOpt;
+use clap::Args;
 
-#[derive(Debug, StructOpt, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Args)]
+#[group(id = "redis")]
 pub struct Config {
-    #[structopt(long = "redis-connection-string", env = "REDIS_CONNECTION_STRING")]
+    #[arg(long = "redis-connection-string", env = "REDIS_CONNECTION_STRING")]
     pub connection_string: String,
-    #[structopt(long = "redis-group-name", env = "REDIS_GROUP_NAME")]
+    #[arg(long = "redis-group-name", env = "REDIS_GROUP_NAME")]
     pub group_name: String,
-    #[structopt(long = "redis-consumer", env = "REDIS_CONSUMER")]
+    #[arg(long = "redis-consumer-name", env = "REDIS_CONSUMER_NAME")]
     pub consumer_name: String,
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,7 +1,7 @@
 pub use crate::{bus::StreamBus, stream::Stream};
 use async_trait::async_trait;
-use futures::channel::mpsc::{channel, Receiver, Sender};
-use futures::{select, SinkExt};
+use futures::channel::mpsc::{Receiver, Sender, channel};
+use futures::{SinkExt, select};
 use futures_util::StreamExt;
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};


### PR DESCRIPTION
This PR replaces `structopt` CLI parser with `clap`. 