### PR TITLE
chore: upgrade redis for compatibility with core repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive", "env"] }
-redis = { version = "0.30", features = ["streams", "tokio-comp", "connection-manager"] }
+redis = { version = "0.31", features = ["streams", "tokio-comp", "connection-manager"] }
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 async-trait = "0.1"


### PR DESCRIPTION
## Description

as mentioned in the PR's comment https://github.com/ezex-io/ezex-core/pull/15#discussion_r2085907590, we need to bump redis version so building on ezex-core can pass
