### PR TITLE
fix: self doesn't need to be mut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ thiserror = "2.0"
 simple_logger = "5.0"
 mockall = "0.13"
 serde_redis = { version = "0.3", git = "https://github.com/ezex-io/serde-redis" }
-tokio = { version = "1.43", features = ["macros"] }
+tokio = { version = "1.45", features = ["macros"] }
 serial_test = "3.2"

--- a/src/client.rs
+++ b/src/client.rs
@@ -163,7 +163,7 @@ impl RedisClient {
     /// * If Entry `id is `None`, Redis will auto-generate an ID (using "*").
     ///
     /// [Redis XADD command documentation](https://redis.io/docs/latest/commands/xadd/)
-    pub async fn xadd(&mut self, entry: Entry) -> Result<String> {
+    pub async fn xadd(&self, entry: Entry) -> Result<String> {
         let mut conn = self.get_async_connection().await?;
 
         let entry_id = match entry.id {
@@ -198,7 +198,7 @@ impl RedisClient {
     /// * The acknowledgment is scoped to this client's `group_name`.
     ///
     /// [Redis XACK command documentation](https://redis.io/docs/latest/commands/xack/)
-    pub async fn xack(&mut self, entry: &Entry) -> Result<String> {
+    pub async fn xack(&self, entry: &Entry) -> Result<String> {
         match &entry.id {
             Some(id) => {
                 let mut conn = self.get_async_connection().await?;
@@ -223,7 +223,7 @@ impl RedisClient {
         }
     }
 
-    pub async fn xread_one(&mut self, key: &str) -> Result<Entry> {
+    pub async fn xread_one(&self, key: &str) -> Result<Entry> {
         let mut conn = self.get_async_connection().await?;
         let read_reply: StreamReadReply = conn
             .xread_options(&[key], &[">"], &self.get_read_options())

--- a/src/client_test.rs
+++ b/src/client_test.rs
@@ -141,7 +141,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_xadd() {
-        let mut ts = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
+        let ts = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
 
         let sent = TestData::new("hello world");
         let entry = Entry::new("test_key", sent.to_value());
@@ -153,7 +153,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_xadd_with_id() {
-        let mut ts = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
+        let ts = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
 
         let start = SystemTime::now();
         let since_the_epoch = start
@@ -172,7 +172,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_xack_unknown_id() {
-        let mut ts = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
+        let ts = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
 
         let sent = TestData::new("hello world");
         let entry = Entry::new("test_key", sent.to_value());
@@ -184,7 +184,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_xack_undelivered_id() {
-        let mut ts = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
+        let ts = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
 
         let sent = TestData::new("hello world");
         let mut entry = Entry::new("test_key", sent.to_value());
@@ -199,7 +199,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_xack_ok() {
-        let mut ts = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
+        let ts = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
 
         let test_key = "key_foo";
         ts.client.create_groups(&[test_key]).await;
@@ -219,7 +219,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_read_one_group() {
-        let mut ts = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
+        let ts = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
 
         let test_key = "key_foo";
         ts.client.create_groups(&[test_key]).await;
@@ -254,7 +254,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_read_two_groups() {
-        let mut ts_1 = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
+        let ts_1 = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
         let ts_2 = Testsuite::create_test_client("group_2", "consumer_1").unwrap();
 
         let test_key = "key_foo";
@@ -303,7 +303,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_two_consumers() {
-        let mut ts_1 = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
+        let ts_1 = Testsuite::create_test_client("group_1", "consumer_1").unwrap();
         let ts_2 = Testsuite::create_test_client("group_1", "consumer_2").unwrap();
 
         let test_key = "key_foo";


### PR DESCRIPTION
## Description

Chang `&mut self` to `&self` in `xadd/xack/xread` functions
